### PR TITLE
Add CI workflows and custom GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../tak-${{ matrix.target }}.tar.gz tak
+          cd ../../..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tak-${{ matrix.target }}
+          path: tak-${{ matrix.target }}.tar.gz
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*.tar.gz

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,57 @@
+name: "tak"
+description: "Determine the next semantic version based on conventional commits"
+branding:
+  icon: "tag"
+  color: "blue"
+
+inputs:
+  increment:
+    description: "The type of version increment (patch, minor, major, auto)"
+    required: false
+    default: "auto"
+  no-prefix:
+    description: "Don't use the 'v' prefix"
+    required: false
+    default: "false"
+  write:
+    description: "Write the tag to the git repository"
+    required: false
+    default: "false"
+
+outputs:
+  version:
+    description: "The next version string (e.g. v1.2.3 or 1.2.3)"
+    value: ${{ steps.tak.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache tak binary
+      id: cache-tak
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/tak
+        key: tak-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Build tak
+      if: steps.cache-tak.outputs.cache-hit != 'true'
+      shell: bash
+      run: cargo install --path ${{ github.action_path }}
+
+    - name: Run tak
+      id: tak
+      shell: bash
+      run: |
+        ARGS="next ${{ inputs.increment }}"
+        if [ "${{ inputs.no-prefix }}" = "true" ]; then
+          ARGS="$ARGS --no-prefix"
+        fi
+        if [ "${{ inputs.write }}" = "true" ]; then
+          ARGS="$ARGS --write"
+        fi
+        VERSION=$(tak $ARGS)
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        echo "Next version: $VERSION"

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: "Write the tag to the git repository"
     required: false
     default: "false"
+  tak-version:
+    description: "Version of tak to use (e.g. 'v0.4.1'). Defaults to latest release."
+    required: false
+    default: "latest"
 
 outputs:
   version:
@@ -26,20 +30,61 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Determine target triple
+      id: target
+      shell: bash
+      run: |
+        case "${{ runner.os }}-${{ runner.arch }}" in
+          Linux-X64)   TARGET="x86_64-unknown-linux-gnu" ;;
+          Linux-ARM64) TARGET="aarch64-unknown-linux-gnu" ;;
+          macOS-X64)   TARGET="x86_64-apple-darwin" ;;
+          macOS-ARM64) TARGET="aarch64-apple-darwin" ;;
+          *)
+            echo "::error::Unsupported platform: ${{ runner.os }}-${{ runner.arch }}"
+            exit 1
+            ;;
+        esac
+        echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+
+    - name: Download tak binary
+      id: download
+      shell: bash
+      run: |
+        TAK_VERSION="${{ inputs.tak-version }}"
+        TARGET="${{ steps.target.outputs.target }}"
+        REPO="reinoudk/tak"
+
+        if [ "$TAK_VERSION" = "latest" ]; then
+          TAG=$(curl -sf "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | cut -d'"' -f4)
+        else
+          TAG="$TAK_VERSION"
+        fi
+
+        if [ -n "$TAG" ]; then
+          URL="https://github.com/${REPO}/releases/download/${TAG}/tak-${TARGET}.tar.gz"
+          echo "Downloading tak ${TAG} for ${TARGET}..."
+          if curl -sfL "$URL" -o /tmp/tak.tar.gz; then
+            sudo tar xzf /tmp/tak.tar.gz -C /usr/local/bin
+            echo "downloaded=true" >> "$GITHUB_OUTPUT"
+            echo "Installed tak ${TAG} from release"
+            exit 0
+          fi
+          echo "::warning::Failed to download tak binary from release, falling back to build"
+        else
+          echo "::warning::No release found, falling back to build"
+        fi
+        echo "downloaded=false" >> "$GITHUB_OUTPUT"
+
     - name: Install Rust toolchain
+      if: steps.download.outputs.downloaded != 'true'
       uses: dtolnay/rust-toolchain@stable
 
-    - name: Cache tak binary
-      id: cache-tak
-      uses: actions/cache@v4
-      with:
-        path: ~/.cargo/bin/tak
-        key: tak-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Build tak
-      if: steps.cache-tak.outputs.cache-hit != 'true'
+    - name: Build tak from source
+      if: steps.download.outputs.downloaded != 'true'
       shell: bash
-      run: cargo install --path ${{ github.action_path }}
+      run: |
+        echo "Building tak from source..."
+        cargo install --path ${{ github.action_path }}
 
     - name: Run tak
       id: tak

--- a/src/bin/tak.rs
+++ b/src/bin/tak.rs
@@ -21,6 +21,6 @@ fn main() {
     if let Err(err) = match &opts.sub_cmd {
         SubCommand::Next(next_opts) => next::exec(next_opts),
     } {
-        eprintln!("Error: {}", err.to_string());
+        eprintln!("Error: {}", err);
     }
 }

--- a/src/cmd/next.rs
+++ b/src/cmd/next.rs
@@ -6,17 +6,17 @@ use crate::increment::Increment;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ArgEnum)]
 enum IncrementArg {
-    PATCH,
-    MINOR,
-    MAJOR,
-    AUTO,
+    Patch,
+    Minor,
+    Major,
+    Auto,
 }
 
 /// Determine the next version
 #[derive(Parser, Debug)]
 pub struct NextOpts {
     /// The type of version increment to use
-    #[clap(arg_enum, default_value_t = IncrementArg::AUTO)]
+    #[clap(arg_enum, default_value_t = IncrementArg::Auto)]
     increment: IncrementArg,
     /// Don't use the 'v' prefix
     #[clap(long, short)]
@@ -31,16 +31,16 @@ pub fn exec(next: &NextOpts) -> Result<()> {
     let repo = SemanticRepository::open_with_prefix(prefix)?;
 
     let new_version = match next.increment {
-        IncrementArg::MAJOR => repo.next_version(Increment::MAJOR),
-        IncrementArg::MINOR => repo.next_version(Increment::MINOR),
-        IncrementArg::PATCH => repo.next_version(Increment::PATCH),
-        IncrementArg::AUTO => repo.automatic_next_version(),
+        IncrementArg::Major => repo.next_version(Increment::Major),
+        IncrementArg::Minor => repo.next_version(Increment::Minor),
+        IncrementArg::Patch => repo.next_version(Increment::Patch),
+        IncrementArg::Auto => repo.automatic_next_version(),
     }?;
 
     if next.write {
         repo.write_version(prefix, &new_version)?;
     }
 
-    println!("{}{}", prefix, new_version.to_string());
+    println!("{}{}", prefix, new_version);
     Ok(())
 }

--- a/src/conventional_commits.rs
+++ b/src/conventional_commits.rs
@@ -7,8 +7,10 @@ use crate::increment::Increment;
 
 pub struct ConventionalCommit {
     change_type: String,
+    #[allow(dead_code)]
     scope: Option<String>,
     is_breaking: bool,
+    #[allow(dead_code)]
     short_description: String,
 }
 
@@ -59,28 +61,27 @@ impl FromStr for ConventionalCommit {
 }
 
 pub fn max_semantic_increment<'a, I: Iterator<Item = &'a str>>(messages: I) -> Increment {
-    let increment = messages.fold(Increment::NONE, |acc, message| {
+    messages.fold(Increment::None, |acc, message| {
         let increment = semantic_increment(message);
 
         // return the biggest increment type
-        return cmp::max(acc, increment);
-    });
-    increment
+        cmp::max(acc, increment)
+    })
 }
 
 fn semantic_increment(message: &str) -> Increment {
-    let mut increment = Increment::NONE;
+    let mut increment = Increment::None;
 
     if let Ok(commit) = message.parse::<ConventionalCommit>() {
         if commit.is_breaking {
             // Increase major on breaking change
-            increment = Increment::MAJOR;
+            increment = Increment::Major;
         } else {
             // Use the value of type to determine increment
             increment = match commit.change_type.as_str() {
-                "fix" => Increment::PATCH,
-                "feat" => Increment::MINOR,
-                _ => Increment::NONE,
+                "fix" => Increment::Patch,
+                "feat" => Increment::Minor,
+                _ => Increment::None,
             }
         }
     }
@@ -106,37 +107,37 @@ mod tests {
         };
     }
 
-    test_semantic_increment!(fix_results_in_patch, "fix: description\n", Increment::PATCH);
+    test_semantic_increment!(fix_results_in_patch, "fix: description\n", Increment::Patch);
     test_semantic_increment!(
         feat_results_in_minor,
         "feat: description\n",
-        Increment::MINOR
+        Increment::Minor
     );
     test_semantic_increment!(
         exclamation_mark_results_in_major,
         "fix!: description\n",
-        Increment::MAJOR
+        Increment::Major
     );
     test_semantic_increment!(
         breaking_change_with_hyphen_in_footer_results_in_major,
         "fix: description\n\nBREAKING-CHANGE: ",
-        Increment::MAJOR
+        Increment::Major
     );
     test_semantic_increment!(
         breaking_change_without_hyphen_in_footer_results_in_major,
         "fix: description\n\nBREAKING CHANGE: ",
-        Increment::MAJOR
+        Increment::Major
     );
     test_semantic_increment!(
         breaking_change_in_footer_without_newline_results_in_major,
         "fix: description\nBREAKING-CHANGE: ",
-        Increment::MAJOR
+        Increment::Major
     );
     test_semantic_increment!(
         breaking_change_in_footer_after_body_results_in_major,
         "fix: description\nsome body\n\nonce told me\n\n\n\nBREAKING-CHANGE: ",
-        Increment::MAJOR
+        Increment::Major
     );
 
-    test_semantic_increment!(missing_space_causes_none, "fix:", Increment::NONE);
+    test_semantic_increment!(missing_space_causes_none, "fix:", Increment::None);
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -33,7 +33,7 @@ impl SemanticRepository {
         self.repository
             .tag_names(None)?
             .iter()
-            .filter_map(|s| s)
+            .flatten()
             .filter_map(|s| s.strip_prefix(&self.prefix))
             .filter_map(|s| Version::parse(s).ok())
             .fold(
@@ -46,14 +46,12 @@ impl SemanticRepository {
             .ok_or(Error::NoTagFound)
     }
 
-    fn commits_since(&self, version: Version) -> Result<Vec<Commit>> {
+    fn commits_since(&self, version: Version) -> Result<Vec<Commit<'_>>> {
         let mut walk = self.repository.revwalk()?;
         walk.push_range(&format!("{}{}..HEAD", &self.prefix, version))?;
         let commits: Vec<Commit> = walk
             .filter_map(std::result::Result::ok)
-            .filter_map(|oid| {
-                return self.repository.find_commit(oid).ok();
-            })
+            .filter_map(|oid| self.repository.find_commit(oid).ok())
             .collect();
 
         Ok(commits)
@@ -65,10 +63,10 @@ impl SemanticRepository {
         let mut new_version = current_version.clone();
 
         match increment {
-            Increment::MAJOR => new_version.increment_major(),
-            Increment::MINOR => new_version.increment_minor(),
-            Increment::PATCH => new_version.increment_patch(),
-            Increment::NONE => return Err(Error::NoVersionChange),
+            Increment::Major => new_version.increment_major(),
+            Increment::Minor => new_version.increment_minor(),
+            Increment::Patch => new_version.increment_patch(),
+            Increment::None => return Err(Error::NoVersionChange),
         };
 
         Ok(new_version)

--- a/src/increment.rs
+++ b/src/increment.rs
@@ -1,7 +1,7 @@
 #[derive(Ord, PartialOrd, Eq, PartialEq, Debug)]
 pub enum Increment {
-    NONE,
-    PATCH,
-    MINOR,
-    MAJOR,
+    None,
+    Patch,
+    Minor,
+    Major,
 }


### PR DESCRIPTION
- Add CI workflow with test (Linux & Mac), clippy, and format checks
- Add release workflow to build binaries for Linux (x86_64, aarch64) and
  Mac (x86_64, aarch64) on tag push, with automatic GitHub release
- Add action.yml so tak can be used as a custom action in other workflows

https://claude.ai/code/session_01V78nmfQAgarxgFPnpssYu9